### PR TITLE
Fix shade plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is especially useful to check what libraries like [Mockito](https://site.mo
 To run it, build the project with `mvn package -DskipTests` and run your Java program with the agent:
 
 ```shell
-java -javaagent:target/meta.jar -jar your-program.jar
+java -javaagent:target/meta-agent.jar -jar your-program.jar
 
 # or run a Mockito based sample test
 mvn package -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,8 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                             <relocations>
                                 <relocation>
                                     <pattern>javassist</pattern>


### PR DESCRIPTION
This configures the shade plugin to output a jar called `meta-agent.jar`. Previously, the `meta-agent.jar` file was throwing a `NoClassDefFoundError`. The file that had to be used was `original-meta-agent.jar`. Now `meta-agent.jar` works.

I didn't spend much time trying to understand this, but it seems to fix it.