### PR TITLE
move batch decompile out of the loop

### DIFF
--- a/src/main/java/me/bechberger/meta/Decompilation.java
+++ b/src/main/java/me/bechberger/meta/Decompilation.java
@@ -51,8 +51,8 @@ public class Decompilation {
                 if (i >= classes.size() - 1) {
                     removeFromProcess.add(className);
                 }
-                result.putAll(decompileClassesWithoutClassNameDuplicates(bytecodePerClassForPackage));
             }
+            result.putAll(decompileClassesWithoutClassNameDuplicates(bytecodePerClassForPackage));
             toProcess.removeAll(removeFromProcess);
         }
         return result;


### PR DESCRIPTION
I think this does the batch decompile multiple times. If we move it out of the loop, it should be faster.