### PR TITLE
Fix initial class loading

### DIFF
--- a/src/main/java/me/bechberger/meta/runtime/InstrumentationHandler.java
+++ b/src/main/java/me/bechberger/meta/runtime/InstrumentationHandler.java
@@ -29,10 +29,6 @@ public class InstrumentationHandler {
         classDiffs.computeIfAbsent(klass, c -> new PerClass()).addDiff(instrumentator, klass, old, current);
     }
 
-    static void addDiff(Instrumentator instrumentator, Class<?> clazz, byte[] old, byte[] current) {
-        addDiff(instrumentator, new Klass(clazz), old, current);
-    }
-
     public static void addDiff(String instrumentator, String clazz, byte[] old, byte[] current) {
         var instr = instrumentatorCache.computeIfAbsent(instrumentator, Instrumentator::new);
         addDiff(instr, new Klass(clazz), old, current);
@@ -92,7 +88,7 @@ public class InstrumentationHandler {
 
                         addDiff(
                                 new Instrumentator(transformer.getClass().getName()),
-                                classBeingRedefined,
+                                new Klass(className, classBeingRedefined),
                                 old,
                                 current);
                         return current;


### PR DESCRIPTION
With 0.4, I noticed many less transformed classes. After a quick investigation, I found out only retransformed transformations were captured (at least using the non native agent).

The issue comes from `ClassFileTransformer.transform()` will be called with a `null` Class during classloading as it's not loaded yet, unlike class retransform. So creating a new `Klass` using `Klass(Class)` will throw a NPE trying to compute the class name.

Here is a minimal patch to fix the issue and restore the capability to capture class transformation at class loading, not only class retransformation.